### PR TITLE
prevent buttons from routing in angular

### DIFF
--- a/templates/layout-full.html
+++ b/templates/layout-full.html
@@ -3,11 +3,11 @@
     <div class='clearfix'>
 
       <div class='half dropdown' style=''>
-        <a id='firechat-btn-rooms' class='dropdown-toggle btn full' data-toggle="dropdown" href='#'>
+        <span id='firechat-btn-rooms' class='dropdown-toggle btn full' data-toggle="dropdown">
           <span class='icon user-chat'></span>
           Chat Rooms
           <span class='caret'></span>
-        </a>
+        </span>
         <div class='dropdown-menu full' role='menu'>
 
           <ul id='firechat-room-list'></ul>
@@ -20,11 +20,11 @@
 
       </div>
       <div class='half dropdown' style=''>
-        <a data-event='firechat-user-search-btn' class='btn full dropdown-toggle' data-toggle="dropdown" href='#'>
+        <span data-event='firechat-user-search-btn' class='btn full dropdown-toggle' data-toggle="dropdown">
           <span class='icon user-group'></span>
           Visitors
           <span class='caret'></span>
-        </a>
+        </span>
         <div class='dropdown-menu' role='menu'>
           <div class='dropdown-header aligncenter clearfix'>
             <div class='search-wrapper'>


### PR DESCRIPTION
If you have angular and firechat loaded, clicking on the 'chat rooms' button would send you to another page. This fixes that.
